### PR TITLE
Efficient shutdown of the worker DynamicSupervisor

### DIFF
--- a/lib/elsa/group/manager.ex
+++ b/lib/elsa/group/manager.ex
@@ -9,7 +9,7 @@ defmodule Elsa.Group.Manager do
   require Logger
   import Record, only: [defrecord: 2, extract: 2]
   import Elsa.Supervisor, only: [registry: 1]
-  alias Elsa.Group.Manager.WorkerManager
+  alias Elsa.Group.Manager.WorkerSupervisor
 
   defrecord :brod_received_assignment, extract(:brod_received_assignment, from_lib: "brod/include/brod.hrl")
 
@@ -189,14 +189,14 @@ defmodule Elsa.Group.Manager do
 
   def handle_call(:revoke_assignments, _from, state) do
     Logger.info("Assignments revoked for group #{state.group}")
-    new_workers = WorkerManager.stop_all_workers(state.connection, state.workers)
+    new_workers = WorkerSupervisor.stop_all_workers(state.connection, state.workers)
     :ok = apply(state.assignments_revoked_handler, [])
     {:reply, :ok, %{state | workers: new_workers, generation_id: nil}}
   end
 
   def handle_info({:DOWN, ref, :process, object, reason}, state) do
     Logger.debug(fn -> "#{__MODULE__}: worker death: #{inspect(object)} - #{inspect(reason)}" end)
-    new_workers = WorkerManager.restart_worker(state.workers, ref, state)
+    new_workers = WorkerSupervisor.restart_worker(state.workers, ref, state)
 
     {:noreply, %{state | workers: new_workers}}
   end
@@ -212,7 +212,7 @@ defmodule Elsa.Group.Manager do
 
   def terminate(reason, state) do
     Logger.debug(fn -> "#{__MODULE__} : Terminating #{state.connection}" end)
-    _ = WorkerManager.stop_all_workers(state.connection, state.workers)
+    _ = WorkerSupervisor.stop_all_workers(state.connection, state.workers)
 
     shutdown_and_wait(state.acknowledger_pid)
     shutdown_and_wait(state.group_coordinator_pid)
@@ -231,7 +231,7 @@ defmodule Elsa.Group.Manager do
 
   defp start_workers(state, generation_id, assignments) do
     Enum.reduce(assignments, state.workers, fn assignment, workers ->
-      WorkerManager.start_worker(workers, generation_id, assignment, state)
+      WorkerSupervisor.start_worker(workers, generation_id, assignment, state)
     end)
   end
 

--- a/lib/elsa/group/manager/worker_supervisor.ex
+++ b/lib/elsa/group/manager/worker_supervisor.ex
@@ -139,7 +139,7 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
     Logger.info("Starting group consumer worker: #{inspect(init_args)}")
 
     supervisor = {:via, ElsaRegistry, {registry(state.connection), :worker_dynamic_supervisor}}
-    {:ok, worker_pid} = DynamicSupervisor.start_child(supervisor, {Elsa.Consumer.Worker, init_args})
+    {:ok, worker_pid} = DynamicSupervisor.start_child(supervisor, {Worker, init_args})
     ref = Process.monitor(worker_pid)
 
     new_worker = %WorkerState{

--- a/lib/elsa/group/manager/worker_supervisor.ex
+++ b/lib/elsa/group/manager/worker_supervisor.ex
@@ -21,12 +21,20 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
     defstruct [:pid, :ref, :generation_id, :topic, :partition, :latest_offset]
   end
 
+  @doc """
+  Start the main Supervisor.  On init this will start a single DynamicSupervisor as a child.
+
+  Options:
+    :connection - Elsa.connection that will identify this supervisor in the Elsa registry.
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) do
     connection = Keyword.fetch!(opts, :connection)
     Supervisor.start_link(__MODULE__, opts, name: {:via, Elsa.Registry, {registry(connection), __MODULE__}})
   end
 
   @impl true
+  @spec init(keyword()) :: {:ok, {Supervisor.sup_flags(), [Supervisor.child_spec()]}}
   def init(opts) do
     connection = Keyword.fetch!(opts, :connection)
 
@@ -37,7 +45,7 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
        [id: :worker_dynamic_supervisor, name: {:via, Elsa.Registry, {registry(connection), :worker_dynamic_supervisor}}]}
     ]
 
-    Supervisor.init(children, strategy: :one_for_one, restart: :transient)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 
   @doc """

--- a/lib/elsa/group/supervisor.ex
+++ b/lib/elsa/group/supervisor.ex
@@ -24,12 +24,9 @@ defmodule Elsa.Group.Supervisor do
 
   @impl Supervisor
   def init(init_arg) do
-    connection = Keyword.fetch!(init_arg, :connection)
-    registry = registry(connection)
-
     children =
       [
-        {DynamicSupervisor, [strategy: :one_for_one, name: {:via, Elsa.Registry, {registry, :worker_supervisor}}]},
+        {Elsa.Group.Manager.WorkerSupervisor, init_arg},
         {Elsa.Group.Manager, manager_args(init_arg)}
       ]
       |> List.flatten()

--- a/test/unit/elsa/group/lifecycle_hooks_test.exs
+++ b/test/unit/elsa/group/lifecycle_hooks_test.exs
@@ -1,14 +1,14 @@
 defmodule Elsa.Group.LifecycleHooksTest do
   use ExUnit.Case
 
-  alias Elsa.Group.Manager.WorkerManager
+  alias Elsa.Group.Manager.WorkerSupervisor
   alias Elsa.Registry
   alias Elsa.Group.Acknowledger
   import Elsa.Group.Manager, only: [brod_received_assignment: 1]
   import Mock
 
   setup_with_mocks([
-    {WorkerManager, [],
+    {WorkerSupervisor, [],
      [
        start_worker: fn _, _, _, _ -> :workers end,
        stop_all_workers: fn _, _ -> :workers end
@@ -70,7 +70,7 @@ defmodule Elsa.Group.LifecycleHooksTest do
         error_state
       )
 
-    assert_not_called(WorkerManager.start_worker(:_, :_, :_, :_))
+    assert_not_called(WorkerSupervisor.start_worker(:_, :_, :_, :_))
   end
 
   test "assignments_revoked calls lifecycle hook", %{state: state} do


### PR DESCRIPTION
https://simplifi.atlassian.net/browse/INT-11113

This is ultimately an attempt to fix https://simplifi.atlassian.net/browse/INT-11003 .

We're having performance issues with partition reassignment because the existing code exits the consumer workers one at a time -- including waiting for them to clean up gracefully.  This was the behavior of DynamicSupervisor.terminate_child...

This change instead stops and restarts the DynamicSupervisor itself.  DynamicSupervisor.stop() will send the exit signal to each child, and then wait for them as a group.