### PR TITLE
Add terminate_child so we get a more reliable shutdown of the dynamic…

### DIFF
--- a/lib/elsa/group/manager/worker_supervisor.ex
+++ b/lib/elsa/group/manager/worker_supervisor.ex
@@ -87,6 +87,10 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
       # Synchronously stops the DynamicSupervisor and its children
       DynamicSupervisor.stop(dynamic_worker_supervisor)
 
+      # Make sure the DynamicSupervisor itself is truly cleaned up from the Supervisor's perspective,
+      # so that it will restart reliably
+      _ = Supervisor.terminate_child(module_supervisor, :worker_dynamic_supervisor)
+
       # Restart the dynamic supervisor
       _ = Supervisor.restart_child(module_supervisor, :worker_dynamic_supervisor)
     end)


### PR DESCRIPTION
https://simplifi.atlassian.net/browse/INT-11129

There seems to be a race condition if you just do
```
# DynamicSupervisor "pid" is a child of supervisor.  Note I already have restart set to :transient, so it isn't being restarted after a normal stop unless we explicitly tell it to.
DynamicSupervisor.stop(pid)
Supervisor.restart_child(supervisor, <supervisor id of pid>)
```

Sometimes the restart_child call will fail, saying that the process is already up.  The log messages look like this:
```
[error] Child {<blah>, :worker_dynamic_supervisor} of Supervisor {<blah>} failed to start
** (exit) already started: #PID<0.1474.0>
```

While DynamicSupervisor.stop() does in fact stop the DynamicSupervisor process itself, it doesn't actually wait for the PID to be gone.  I believe the solution is to add a `Supervisor.terminate_child` in between, as this actually will clean everything up from the Supervisor's perspective.