### PR TITLE
Couple more stability fixes

### DIFF
--- a/lib/elsa/elsa_supervisor.ex
+++ b/lib/elsa/elsa_supervisor.ex
@@ -76,6 +76,10 @@ defmodule Elsa.ElsaSupervisor do
   * `:assignments_revoked_handler` - Optional. Zero arity function that will be called when assignments are revoked.
     All workers will be shutdown before callback is invoked and must return `:ok`.
 
+  * `:worker_supervisor_max_restarts` - Optional. max_restarts option passed to the WorkerSupervisor.  Default 30.
+
+  # `:worker_supervisor_max_seconds` - Optional. max_seconds option passed to the WorkerSupervisor.  Default 5.
+
   * `:config` - Optional. Consumer configuration options passed to `brod_consumer`.
 
 

--- a/lib/elsa/group/manager.ex
+++ b/lib/elsa/group/manager.ex
@@ -191,7 +191,7 @@ defmodule Elsa.Group.Manager do
   end
 
   def handle_call(:revoke_assignments, _from, state) do
-    Logger.info("Assignments revoked for group #{state.group}")
+    Logger.info("#{__MODULE__}: Assignments revoked for group #{state.group}")
     new_workers = WorkerSupervisor.stop_all_workers(state.connection, state.workers)
     :ok = apply(state.assignments_revoked_handler, [])
     {:reply, :ok, %{state | workers: new_workers, generation_id: nil}}
@@ -215,7 +215,7 @@ defmodule Elsa.Group.Manager do
 
   def terminate(reason, state) do
     Logger.debug(fn -> "#{__MODULE__} : Terminating #{state.connection}" end)
-    _ = WorkerSupervisor.stop_all_workers(state.connection, state.workers)
+    _ = WorkerSupervisor.stop_all_workers(state.connection, state.workers, restart_supervisor: false)
 
     shutdown_and_wait(state.acknowledger_pid)
     shutdown_and_wait(state.group_coordinator_pid)


### PR DESCRIPTION
https://simplifi.atlassian.net/browse/INT-11129

I know the ticket talks about a race condition, but after poking with it more today I'm not sure it's actually a race condition causing the problem -- there are a couple of other things that seem to impact the stability, at least when running the integration tests:

* First off we were trying to restart the WorkerSupervisor's DynamicSupervisor when handling a termination.  I don't know this actually broke anything, but it's messy so I fixed it.

* Added worker_supervisor max_restart and max_seconds options.  We were certainly having problems because the defaults for these were too low (see the comments in the code)