### PR TITLE
Update acknowledger when we get assignments from the consumer group

### DIFF
--- a/lib/elsa/group/acknowledger.ex
+++ b/lib/elsa/group/acknowledger.ex
@@ -114,8 +114,7 @@ defmodule Elsa.Group.Acknowledger do
         # This should never happen, but if it does this check will avoid causing a rewind.
         Logger.warn(
           "#{__MODULE__} Ignoring :set_latest_offset - \
-          it was called for topic #{topic}, partition #{partition} with an offset less than the existing one. \
-          (#{offset} < #{existing_offset})")
+          it was called for topic #{topic}, partition #{partition} with an offset (#{offset}) less than the existing one (#{existing_offset}).")
         existing_offset
       else
         offset

--- a/lib/elsa/group/acknowledger.ex
+++ b/lib/elsa/group/acknowledger.ex
@@ -108,18 +108,21 @@ defmodule Elsa.Group.Acknowledger do
 
   @impl GenServer
   def handle_call({:set_latest_offset, topic, partition, offset}, _pid, state) do
-    new_offsets = Map.update(state.current_offsets, {topic, partition}, offset, fn existing_offset ->
-      if offset < existing_offset do
-        # If this was called with an older offset, ignore it and log a warning.
-        # This should never happen, but if it does this check will avoid causing a rewind.
-        Logger.warn(
-          "#{__MODULE__} Ignoring :set_latest_offset - \
-          it was called for topic #{topic}, partition #{partition} with an offset (#{offset}) less than the existing one (#{existing_offset}).")
-        existing_offset
-      else
-        offset
-      end
-    end)
+    new_offsets =
+      Map.update(state.current_offsets, {topic, partition}, offset, fn existing_offset ->
+        if offset < existing_offset do
+          # If this was called with an older offset, ignore it and log a warning.
+          # This should never happen, but if it does this check will avoid causing a rewind.
+          Logger.warn(
+            "#{__MODULE__} Ignoring :set_latest_offset - \
+          it was called for topic #{topic}, partition #{partition} with an offset (#{offset}) less than the existing one (#{existing_offset})."
+          )
+
+          existing_offset
+        else
+          offset
+        end
+      end)
 
     {:reply, :ok, %{state | current_offsets: new_offsets}}
   end

--- a/test/unit/elsa/group/acknowledger_test.exs
+++ b/test/unit/elsa/group/acknowledger_test.exs
@@ -46,4 +46,22 @@ defmodule Elsa.Group.AcknowledgerTest do
 
     assert 2 == :sys.get_state(acknowledger).generation_id
   end
+
+  test "adds a new partition offset with a set call", %{acknowledger: acknowledger} do
+    assert nil == Acknowledger.get_latest_offset(acknowledger, "elsa-topic", 2)
+    :ok = Acknowledger.set_latest_offset(acknowledger, "elsa-topic", 2, 0)
+    assert 0 = Acknowledger.get_latest_offset(acknowledger, "elsa-topic", 2)
+  end
+
+  test "updates existing offset with a set call", %{acknowledger: acknowledger} do
+    assert 2 == Acknowledger.get_latest_offset(acknowledger, "elsa-topic", 0)
+    :ok = Acknowledger.set_latest_offset(acknowledger, "elsa-topic", 0, 3)
+    assert 3 = Acknowledger.get_latest_offset(acknowledger, "elsa-topic", 0)
+  end
+
+  test "ignores set call when new offset < existing offset", %{acknowledger: acknowledger} do
+    assert 2 == Acknowledger.get_latest_offset(acknowledger, "elsa-topic", 0)
+    :ok = Acknowledger.set_latest_offset(acknowledger, "elsa-topic", 0, 1)
+    assert 2 = Acknowledger.get_latest_offset(acknowledger, "elsa-topic", 0)
+  end
 end

--- a/test/unit/elsa/group/manager/worker_supervisor_test.exs
+++ b/test/unit/elsa/group/manager/worker_supervisor_test.exs
@@ -8,8 +8,8 @@ defmodule Elsa.Group.Manager.WorkerSupervisorTest do
   alias Elsa.ElsaRegistry
   alias Elsa.ElsaSupervisor
   alias Elsa.Group.Acknowledger
-  alias Elsa.Group.Manager.WorkerSupervisor
   alias Elsa.Group.Manager.State
+  alias Elsa.Group.Manager.WorkerSupervisor
 
   defrecord :brod_received_assignment, extract(:brod_received_assignment, from_lib: "brod/include/brod.hrl")
 

--- a/test/unit/elsa/group/manager/worker_supervisor_test.exs
+++ b/test/unit/elsa/group/manager/worker_supervisor_test.exs
@@ -1,0 +1,74 @@
+defmodule Elsa.Group.Manager.WorkerSupervisorTest do
+  use ExUnit.Case
+
+  import Mock
+  import Record, only: [defrecord: 2, extract: 2]
+
+  alias Elsa.Consumer.Worker
+  alias Elsa.ElsaRegistry
+  alias Elsa.ElsaSupervisor
+  alias Elsa.Group.Acknowledger
+  alias Elsa.Group.Manager.WorkerSupervisor
+  alias Elsa.Group.Manager.State
+
+  defrecord :brod_received_assignment, extract(:brod_received_assignment, from_lib: "brod/include/brod.hrl")
+
+  @topic "worker_sup_test"
+  @connection :worker_sup_test
+
+  defmodule FakeWorker do
+    use GenServer
+
+    def start_link(args) do
+      GenServer.start_link(__MODULE__, args)
+    end
+
+    def init(args) do
+      {:ok, args}
+    end
+  end
+
+  setup_with_mocks([
+    {Worker, [],
+     [
+       child_spec: &FakeWorker.child_spec/1
+     ]}
+  ]) do
+    {:ok, registry} = start_supervised({ElsaRegistry, [name: ElsaSupervisor.registry(@connection)]})
+
+    :yes = ElsaRegistry.register_name({registry, :brod_group_coordinator}, self())
+
+    start_supervised({WorkerSupervisor, [connection: @connection]})
+
+    {:ok, acknowledger} = start_supervised({Acknowledger, [connection: @connection]})
+
+    [acknowledger: acknowledger]
+  end
+
+  test "start_worker updates acknowledger immediately with offsets", %{acknowledger: acknowledger} do
+    partition = 0
+    test_offset = 5
+
+    WorkerSupervisor.start_worker(
+      %{},
+      partition,
+      brod_received_assignment(topic: @topic, partition: partition, begin_offset: test_offset),
+      %State{connection: @connection, acknowledger_pid: acknowledger}
+    )
+
+    assert test_offset == Acknowledger.get_latest_offset(acknowledger, @topic, partition)
+  end
+
+  test "start_worker doesn't set anything on Acknowledger if begin_offset is undefined", %{acknowledger: acknowledger} do
+    partition = 0
+
+    WorkerSupervisor.start_worker(
+      %{},
+      partition,
+      brod_received_assignment(topic: @topic, partition: partition, begin_offset: :undefined),
+      %State{connection: @connection, acknowledger_pid: acknowledger}
+    )
+
+    assert nil == Acknowledger.get_latest_offset(acknowledger, @topic, partition)
+  end
+end


### PR DESCRIPTION
https://simplifi.atlassian.net/browse/INT-11275

This is a bugfix:

* Consumer worker threads only live for a single assignment.  Once assignments are revoked, those threads are destroyed...
* BUT, there is another GenServer called the Acknowledger, that stays alive for the duration of the connection.  The Acknowledger tracks the latest offset that it's seen for each partition...
* Normally, when worker threads are started they get their beginning offset from the broker, BUT when they are restarted because of an unexpected crash (say, our json writers timing out) they attempt to restore their offset from the Acknowledger.

In the original code, this can cause a rewind if the worker crashes before actually acking any new offsets.

This PR fixes that by updating the Acknowledger's latest offset as soon as we see a new partition assignment from the broker.