### PR TITLE
Rework Elsa.Util.get_partition_count to optionally retry on failure

### DIFF
--- a/lib/elsa/consumer/worker/initializer.ex
+++ b/lib/elsa/consumer/worker/initializer.ex
@@ -2,7 +2,6 @@ defmodule Elsa.Consumer.Worker.Initializer do
   @moduledoc false
 
   alias Elsa.ElsaRegistry
-  alias Elsa.RetryConfig
   alias Elsa.Util
 
   @type init_opts :: [
@@ -28,12 +27,12 @@ defmodule Elsa.Consumer.Worker.Initializer do
   end
 
   defp configure_topic(topic, registry, brod_client, init_arg) do
-    retry_config = RetryConfig.new(Keyword.get(init_arg, :metadata_request_config, []))
+    retry_config = Elsa.RetryConfig.new(Keyword.get(init_arg, :metadata_request_config, []))
 
     # Use the non-connection based partition_count.
     # This circumvents a behavior in brod that caches topics as non-existent,
     # which would break our ability to retry.
-    {:ok, endpoints} = Elsa.Util.get_endpoints(brod_client)
+    {:ok, endpoints} = Util.get_endpoints(brod_client)
 
     Util.partition_count!(endpoints, topic, retry_config)
     |> to_child_specs(registry, topic, init_arg)

--- a/lib/elsa/elsa_supervisor.ex
+++ b/lib/elsa/elsa_supervisor.ex
@@ -58,6 +58,8 @@ defmodule Elsa.ElsaSupervisor do
 
   * `:config` - Optional. Producer configuration options passed to `brod_producer`.
 
+  * `:metadata_request_config` - Optional. See Metadata Request Config
+
 
   ## Group Consumer Config
 
@@ -82,6 +84,8 @@ defmodule Elsa.ElsaSupervisor do
 
   * `:config` - Optional. Consumer configuration options passed to `brod_consumer`.
 
+  * `:metadata_request_config` - Optional. See Metadata Request Config
+
 
   ## Consumer Config
 
@@ -96,6 +100,23 @@ defmodule Elsa.ElsaSupervisor do
   * `:handler_init_args` - Optional. Any args to be passed to init function in handler module.
 
   * `:poll` - Optional. If set to number of milliseconds, will poll for new partitions and startup consumers on the fly.
+
+  * `:metadata_request_config` - Optional. See Metadata Request Config
+
+
+  ## Metadata Request Config
+
+  * `:metadata_request_tries` - Optional, default 5.  The number of tries allowed when querying topic metadata.
+    Typically these retries are necessary when creating topics on the fly and immediately attempting to connect
+    a producer or consumer to them.  That's because topic creation in kafka is asynchronous -- even though a
+    call to Elsa.create_topic may return success, that doesn't mean that the metadata for that new topic has
+    propagated to all the brokers.
+
+    The defaults for `metadata_request_tries` and `metadata_request_dwell_ms` work well for testing with kafka in a
+    local docker container. These values may need to be increased if creating topics on the fly with remote kafka
+    brokers.
+
+  * `:metadata_request_dwell_ms` - Optional, default 100.  The amount of time to wait between tries when querying topic metadata.
 
 
   ## Example

--- a/lib/elsa/fetch.ex
+++ b/lib/elsa/fetch.ex
@@ -43,7 +43,7 @@ defmodule Elsa.Fetch do
     partitions =
       case Keyword.get(opts, :partition) do
         nil ->
-          0..(Elsa.Util.partition_count(endpoints, topic) - 1)
+          0..(Elsa.Util.partition_count!(endpoints, topic) - 1)
 
         partition ->
           [partition]

--- a/lib/elsa/producer.ex
+++ b/lib/elsa/producer.ex
@@ -24,6 +24,7 @@ defmodule Elsa.Producer do
   @type message :: {iodata(), iodata()} | binary() | %{key: iodata(), value: iodata()}
 
   alias Elsa.ElsaRegistry
+  alias Elsa.RetryConfig
   alias Elsa.Util
 
   @doc """
@@ -142,7 +143,7 @@ defmodule Elsa.Producer do
     Elsa.Util.with_client(registry, fn client ->
       case Keyword.get(opts, :partition) do
         nil ->
-          {:ok, partition_num} = :brod_client.get_partitions_count(client, topic)
+          {:ok, partition_num} = Util.partition_count(client, topic, RetryConfig.no_retry())
           partitioner = Keyword.get(opts, :partitioner, Elsa.Partitioner.Default) |> remap_deprecated()
           {:ok, fn %{key: key} -> partitioner.partition(partition_num, key) end}
 

--- a/lib/elsa/producer/initializer.ex
+++ b/lib/elsa/producer/initializer.ex
@@ -1,4 +1,6 @@
 defmodule Elsa.Producer.Initializer do
+  alias Elsa.RetryConfig
+
   @moduledoc false
   @spec init(registry :: atom(), producer_configs :: list(keyword)) :: [Supervisor.child_spec()]
   def init(registry, producer_configs) do
@@ -19,8 +21,13 @@ defmodule Elsa.Producer.Initializer do
   defp child_spec(registry, brod_client, producer_config) do
     topic = Keyword.fetch!(producer_config, :topic)
     config = Keyword.get(producer_config, :config, [])
+    retry_config = RetryConfig.new(Keyword.get(producer_config, :metadata_request_config, []))
 
-    partitions = Elsa.Util.partition_count(brod_client, topic)
+    # Use the non-connection based partition_count.
+    # This circumvents a behavior in brod that caches topics as non-existent,
+    # which would break our ability to retry.
+    {:ok, endpoints} = Elsa.Util.get_endpoints(brod_client)
+    {:ok, partitions} = Elsa.Util.partition_count(endpoints, topic, retry_config)
 
     0..(partitions - 1)
     |> Enum.map(fn partition ->

--- a/lib/elsa/retry_config.ex
+++ b/lib/elsa/retry_config.ex
@@ -1,0 +1,40 @@
+defmodule Elsa.RetryConfig do
+  @moduledoc """
+  Simple struct for metadata request configuration, with function to provide defaults
+  """
+  defstruct [
+    :tries,
+    :dwell_ms
+  ]
+
+  @type t :: %__MODULE__{}
+
+  @doc """
+  Generate a struct from a keyword list with :tries and :dwell_ms.
+  Both keyword list entries are optional, and will be substituded with defaults if missing.
+  Default tries: 5
+  Default dwell_ms: 100
+  """
+  @spec new(keyword()) :: t()
+  def new(config) when is_list(config) do
+    %__MODULE__{
+      tries: Keyword.get(config, :tries, 5),
+      dwell_ms: Keyword.get(config, :dwell_ms, 100)
+    }
+  end
+
+  @doc "Return a retry config that doesn't retry at all"
+  @spec no_retry() :: t()
+  def no_retry do
+    %__MODULE__{
+      tries: 1,
+      dwell_ms: 0
+    }
+  end
+
+  @doc "Decrement the tries field by 1"
+  @spec decrement(t()) :: t()
+  def decrement(%__MODULE__{tries: tries, dwell_ms: dwell_ms}) do
+    %__MODULE__{tries: tries - 1, dwell_ms: dwell_ms}
+  end
+end

--- a/lib/elsa/util.ex
+++ b/lib/elsa/util.ex
@@ -5,6 +5,10 @@ defmodule Elsa.Util do
   client process for interacting with a cluster.
   """
 
+  require Logger
+
+  alias Elsa.RetryConfig
+
   @default_max_chunk_size 900_000
   @timestamp_size_in_bytes 10
 
@@ -89,6 +93,7 @@ defmodule Elsa.Util do
     :brod.start_client(endpoints, name, config)
   end
 
+  @spec chunk_by_byte_size(any(), integer()) :: list()
   @doc """
   Process messages into chunks of size up to the size specified by the calling function in bytes,
   and determined by the function argument. If no chunk size is specified the default maximum
@@ -104,18 +109,67 @@ defmodule Elsa.Util do
   @doc """
   Return the number of partitions for a given topic. Bypasses the need for a persistent client
   for lighter weight interactions from one-off calls.
-  """
-  @spec partition_count(keyword | Elsa.connection() | pid, String.t()) :: integer()
-  def partition_count(endpoints, topic) when is_list(endpoints) do
-    {:ok, metadata} = :brod.get_metadata(reformat_endpoints(endpoints), [topic])
 
-    count_partitions(metadata)
+  Note that when passing in a connection/pid for the first argument, the underlying brod calls
+  will cache the results, including the non-existence of a topic!  So if this function is being
+  used to wait for a recently created topic to be fully online, pass in a list of endpoints
+  rather than a connection.  For convenience, the `get_endpoints/1` is provided to extract
+  the endpoints from a connection.
+  """
+  @spec partition_count(list() | Elsa.connection() | pid(), String.t(), RetryConfig.t()) ::
+          {:ok, integer()} | {:error, any()}
+  def partition_count(connection_or_endpoints, topic, retry_config \\ RetryConfig.no_retry())
+  def partition_count(_client_or_endpoints, _topic, %RetryConfig{tries: 0}) do
+    {:error, :out_of_tries}
   end
 
-  def partition_count(connection, topic) when is_atom(connection) or is_pid(connection) do
-    {:ok, metadata} = :brod_client.get_metadata(connection, topic)
+  def partition_count(endpoints, topic, %RetryConfig{} = retry_config) when is_list(endpoints) do
+    case :brod.get_metadata(reformat_endpoints(endpoints), [topic]) do
+      {:ok, metadata} ->
+        {:ok, count_partitions(metadata)}
 
-    count_partitions(metadata)
+      {:error, reason} ->
+        Logger.info("#{__MODULE__}: error #{reason}. retrying get_partitions count for #{topic}")
+        :timer.sleep(retry_config.dwell_ms)
+        partition_count(endpoints, topic, RetryConfig.decrement(retry_config))
+    end
+  end
+
+  def partition_count(client, topic, %RetryConfig{} = retry_config) when is_atom(client) or is_pid(client) do
+    case :brod_client.get_partitions_count(client, topic) do
+      {:ok, partition_num} ->
+        {:ok, partition_num}
+
+      {:error, reason} ->
+        Logger.info("#{__MODULE__}: error #{reason}. retrying get_partitions count for #{topic}")
+        :timer.sleep(retry_config.dwell_ms)
+        partition_count(client, topic, RetryConfig.decrement(retry_config))
+    end
+  end
+
+  @doc """
+  Like `partition_count/3` but returns only the partition count, and raises on failure
+  """
+  @spec partition_count!(list() | Elsa.connection() | pid, String.t(), RetryConfig.t()) :: integer()
+  def partition_count!(connection_or_endpoints, topic, retry_config \\ RetryConfig.no_retry())
+
+  def partition_count!(connection_or_endpoints, topic, %RetryConfig{} = retry_config) do
+    case partition_count(connection_or_endpoints, topic, retry_config) do
+      {:ok, partition_count} ->
+        partition_count
+
+      {:error, error} ->
+        raise "#{__MODULE__}.partition_count! failed: #{error}"
+    end
+  end
+
+  @spec get_endpoints(Elsa.connection()) :: {:ok, list()} | {:error, any}
+  def get_endpoints(connection) do
+    case :brod_client.get_bootstrap(connection) do
+      {:ok, {endpoints, _}} -> {:ok, endpoints}
+      {:ok, endpoints} -> {:ok, endpoints}
+      error -> error
+    end
   end
 
   # Handle brod < 3.16


### PR DESCRIPTION
https://simplifi.atlassian.net/browse/INT-11108

The basic problem is that creating topics in Kafka is asychronous, so unit tests that create topics tend to fail if we try to produce to them immediately afterwards.  It turns out part of the reason this is so fatal, is that brod likes to cache topic non-existence once you've had a failed query.

This PR adds intentional retries when we're trying to pull the partition count from topic metadata.  It also uses non-client based brod calls to make these queries (i.e. you just give it endpoints instead of a brod_client), to get around that caching behavior.