### PR TITLE
Assignments complete callback.  Fix race condition in WorkerSupervisor.  Fix error in WorkerSupervisor supervision tree.   Improve lifecycle callback documentation.

### DIFF
--- a/config/integration.exs
+++ b/config/integration.exs
@@ -6,5 +6,5 @@ config :elsa_fi,
   divo_wait: [dwell: 700, max_tries: 50]
 
 config :logger,
-  handle_sasl_reports: false,
+  handle_sasl_reports: true,
   level: :warn

--- a/lib/elsa/elsa_supervisor.ex
+++ b/lib/elsa/elsa_supervisor.ex
@@ -71,21 +71,28 @@ defmodule Elsa.ElsaSupervisor do
 
   * `:handler_init_args` - Optional. Any args to be passed to init function in handler module.
 
-  * `:assignment_received_handler` - Optional. Arity 4 function that will be called with any partition assignments.
-     Return `:ok` to for assignment to be subscribed to.  Return `{:error, reason}` to stop subscription.
-     Arguments are group, topic, partition, generation_id.
+  * `:assignment_received_handler` - Optional. Will be called with any partition assignments.
+    See `t:Elsa.Group.Manager.assignment_received_handler/0` for expected function arity and types.
 
-  * `assignments_complete_handler` - Optional.  Arity 3 function that will be called after each batch of partition assignments.
+    This function will be called once per assignment with arguments (group, topic, partition, generation_id).
+
+    Return `:ok` to allow subscription to the current assignment.  Return `{:error, reason}` to stop subscription.
+
+  * `:assignments_complete_handler` - Optional.  Will be called after each batch of partition assignments.
+    See `t:Elsa.Group.Manager.assignments_complete_handler/0` for expected function arity and types.
+
     If subscription is successful, this function will be called after all workers are started with (group, generation_id, :ok).
-    If subscription is unsuccessful, this function will be called with (group, generation_id, {:error, reason}).
-    Must return `:ok`.
 
-  * `:assignments_revoked_handler` - Optional. Zero arity function that will be called when assignments are revoked.
-    All workers will be shutdown before callback is invoked and must return `:ok`.
+    If subscription is unsuccessful, this function will be called with (group, generation_id, {:error, reason}).
+
+  * `:assignments_revoked_handler` - Optional. Will be called when assignments are revoked.
+    See `t:Elsa.Group.Manager.assignments_revoked_handler/0` for expected function arity and types.
+
+    All workers will be shut down before this function is called.
 
   * `:worker_supervisor_max_restarts` - Optional. max_restarts option passed to the WorkerSupervisor.  Default 30.
 
-  # `:worker_supervisor_max_seconds` - Optional. max_seconds option passed to the WorkerSupervisor.  Default 5.
+  * `:worker_supervisor_max_seconds` - Optional. max_seconds option passed to the WorkerSupervisor.  Default 5 seconds.
 
   * `:config` - Optional. Consumer configuration options passed to `brod_consumer`.
 

--- a/lib/elsa/elsa_supervisor.ex
+++ b/lib/elsa/elsa_supervisor.ex
@@ -71,9 +71,14 @@ defmodule Elsa.ElsaSupervisor do
 
   * `:handler_init_args` - Optional. Any args to be passed to init function in handler module.
 
-  * `:assignment_received_handler` - Optional. Arity 4 Function that will be called with any partition assignments.
+  * `:assignment_received_handler` - Optional. Arity 4 function that will be called with any partition assignments.
      Return `:ok` to for assignment to be subscribed to.  Return `{:error, reason}` to stop subscription.
      Arguments are group, topic, partition, generation_id.
+
+  * `assignments_complete_handler` - Optional.  Arity 3 function that will be called after each batch of partition assignments.
+    If subscription is successful, this function will be called after all workers are started with (group, generation_id, :ok).
+    If subscription is unsuccessful, this function will be called with (group, generation_id, {:error, reason}).
+    Must return `:ok`.
 
   * `:assignments_revoked_handler` - Optional. Zero arity function that will be called when assignments are revoked.
     All workers will be shutdown before callback is invoked and must return `:ok`.

--- a/lib/elsa/group/manager.ex
+++ b/lib/elsa/group/manager.ex
@@ -28,6 +28,10 @@ defmodule Elsa.Group.Manager do
   @type assignment_received_handler ::
           (group(), Elsa.topic(), Elsa.partition(), generation_id() -> :ok | {:error, term()})
 
+  @typedoc "Function called each time a batch of assignments is complete"
+  @type assignments_complete_handler ::
+          (group(), generation_id(), :ok | {:error, term()} -> :ok)
+
   @typedoc "Function called for when assignments have been revoked"
   @type assignments_revoked_handler :: (() -> :ok)
 
@@ -75,6 +79,7 @@ defmodule Elsa.Group.Manager do
           topics: [Elsa.topic()],
           assignment_received_handler: assignment_received_handler(),
           assignments_revoked_handler: assignments_revoked_handler(),
+          assignments_complete_handler: assignments_complete_handler(),
           handler: handler(),
           handler_init_args: term(),
           config: consumer_config()
@@ -95,6 +100,7 @@ defmodule Elsa.Group.Manager do
       :group_coordinator_pid,
       :acknowledger_pid,
       :assignment_received_handler,
+      :assignments_complete_handler,
       :assignments_revoked_handler,
       :start_time,
       :delay,
@@ -150,6 +156,7 @@ defmodule Elsa.Group.Manager do
       topics: Keyword.fetch!(opts, :topics),
       supervisor_pid: Keyword.fetch!(opts, :supervisor_pid),
       assignment_received_handler: Keyword.get(opts, :assignment_received_handler, fn _g, _t, _p, _gen -> :ok end),
+      assignments_complete_handler: Keyword.get(opts, :assignments_complete_handler, fn _g, _gen, _res -> :ok end),
       assignments_revoked_handler: Keyword.get(opts, :assignments_revoked_handler, fn -> :ok end),
       start_time: :erlang.system_time(:milli_seconds),
       delay: Keyword.get(opts, :delay, @default_delay),
@@ -175,19 +182,27 @@ defmodule Elsa.Group.Manager do
   def handle_call({:process_assignments, _member_id, generation_id, assignments}, _from, state) do
     Logger.debug(fn -> "#{__MODULE__}: process assignments #{inspect(assignments)}" end)
 
-    case call_lifecycle_assignment_received(state, assignments, generation_id) do
-      {:error, reason} ->
-        {:stop, reason, {:error, reason}, state}
+    result = call_lifecycle_assignment_received(state, assignments, generation_id)
 
-      :ok ->
-        Acknowledger.update_generation_id(
-          {:via, ElsaRegistry, {registry(state.connection), Acknowledger}},
-          generation_id
-        )
+    call_return =
+      case result do
+        {:error, reason} ->
+          {:stop, reason, {:error, reason}, state}
 
-        new_workers = start_workers(state, generation_id, assignments)
-        {:reply, :ok, %{state | workers: new_workers, generation_id: generation_id}}
-    end
+        :ok ->
+          Acknowledger.update_generation_id(
+            {:via, ElsaRegistry, {registry(state.connection), Acknowledger}},
+            generation_id
+          )
+
+          new_workers = start_workers(state, generation_id, assignments)
+
+          {:reply, :ok, %{state | workers: new_workers, generation_id: generation_id}}
+      end
+
+    apply(state.assignments_complete_handler, [state.group, generation_id, result])
+
+    call_return
   end
 
   def handle_call(:revoke_assignments, _from, state) do
@@ -214,7 +229,7 @@ defmodule Elsa.Group.Manager do
   end
 
   def terminate(reason, state) do
-    Logger.debug(fn -> "#{__MODULE__} : Terminating #{state.connection}" end)
+    Logger.debug(fn -> "#{__MODULE__} : Terminating #{state.connection}, reason: #{inspect(reason)}" end)
     _ = WorkerSupervisor.stop_all_workers(state.connection, state.workers, restart_supervisor: false)
 
     shutdown_and_wait(state.acknowledger_pid)

--- a/lib/elsa/group/manager/worker_supervisor.ex
+++ b/lib/elsa/group/manager/worker_supervisor.ex
@@ -112,6 +112,7 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
     # Restart the dynamic supervisor
     if Keyword.get(options, :restart_supervisor, true) do
       {:ok, _pid} = Supervisor.restart_child(module_supervisor, @dynamic_supervisor_id)
+      :ok
     end
 
     %{}

--- a/lib/elsa/group/manager/worker_supervisor.ex
+++ b/lib/elsa/group/manager/worker_supervisor.ex
@@ -104,6 +104,10 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
         # Make sure the DynamicSupervisor itself is truly cleaned up from the Supervisor's perspective,
         # so that it will restart reliably
         _ = Supervisor.terminate_child(module_supervisor, :worker_dynamic_supervisor)
+
+        # If terminate_child failed because the dynamic supervisor was dead, that can be safely ignored.
+        # Return :ok here from the if block so dialyzer doesn't get upset.
+        :ok
       else
         Logger.warn(
           "#{__MODULE__}: Attempted to stop :worker_dynamic_supervisor, but it does not exist under #{inspect(connection)}"
@@ -112,7 +116,7 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
 
       # Restart the dynamic supervisor
       if Keyword.get(options, :restart_supervisor, true) do
-        _ = Supervisor.restart_child(module_supervisor, :worker_dynamic_supervisor)
+        {:ok, _pid} = Supervisor.restart_child(module_supervisor, :worker_dynamic_supervisor)
       end
     end)
 

--- a/lib/elsa/group/manager/worker_supervisor.ex
+++ b/lib/elsa/group/manager/worker_supervisor.ex
@@ -20,6 +20,10 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
 
   defrecord :brod_received_assignment, extract(:brod_received_assignment, from_lib: "brod/include/brod.hrl")
 
+  # ID used for the underlying DynamicSupervisor.
+  # Defined as a module attribute to avoid typo bugs.
+  @dynamic_supervisor_id :worker_dynamic_supervisor
+
   defmodule WorkerState do
     @moduledoc """
     Tracks the running state of the worker process from the perspective of the group manager.
@@ -42,14 +46,10 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
   @impl true
   @spec init(keyword()) :: {:ok, {Supervisor.sup_flags(), [Supervisor.child_spec()]}}
   def init(opts) do
-    connection = Keyword.fetch!(opts, :connection)
-
     children = [
       %{
-        id: :worker_dynamic_supervisor,
-        start:
-          {DynamicSupervisor, :start_link,
-           [[name: {:via, ElsaRegistry, {registry(connection), :worker_dynamic_supervisor}}]]},
+        id: @dynamic_supervisor_id,
+        start: {DynamicSupervisor, :start_link, [[]]},
         restart: :transient
       }
     ]
@@ -82,6 +82,8 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
   """
   @spec stop_all_workers(Elsa.connection(), map(), list()) :: map()
   def stop_all_workers(connection, workers, options \\ []) do
+    Logger.info("Stopping all workers for #{inspect(connection)}")
+
     # Demonitor all the workers, so that our client doesn't get a bunch of :EXIT signals
     workers
     |> Map.values()
@@ -90,35 +92,27 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
       Process.demonitor(worker.ref)
     end)
 
-    # Stop the dynamic supervisor in , which will in turn stop all of the children
-    Util.with_registry(connection, fn registry ->
-      # This is the Supervisor created in start_link, for this specific connection.
-      module_supervisor = ElsaRegistry.whereis_name({registry, __MODULE__})
-      # This is the DynamicSupervisor created in init
-      dynamic_worker_supervisor = ElsaRegistry.whereis_name({registry, :worker_dynamic_supervisor})
+    module_supervisor = get_worker_supervisor(connection)
 
-      if dynamic_worker_supervisor != :undefined do
-        # Synchronously stops the DynamicSupervisor and its children
-        DynamicSupervisor.stop(dynamic_worker_supervisor)
+    dynamic_worker_supervisor = get_dynamic_supervisor(module_supervisor)
 
-        # Make sure the DynamicSupervisor itself is truly cleaned up from the Supervisor's perspective,
-        # so that it will restart reliably
-        _ = Supervisor.terminate_child(module_supervisor, :worker_dynamic_supervisor)
+    if dynamic_worker_supervisor != :undefined do
+      # Synchronously stops the DynamicSupervisor and its children
+      DynamicSupervisor.stop(dynamic_worker_supervisor)
+    else
+      Logger.warning(
+        "#{__MODULE__}: Attempted to stop #{@dynamic_supervisor_id}, but it does not exist under Supervisor #{inspect(module_supervisor)}"
+      )
+    end
 
-        # If terminate_child failed because the dynamic supervisor was dead, that can be safely ignored.
-        # Return :ok here from the if block so dialyzer doesn't get upset.
-        :ok
-      else
-        Logger.warn(
-          "#{__MODULE__}: Attempted to stop :worker_dynamic_supervisor, but it does not exist under #{inspect(connection)}"
-        )
-      end
+    # Make sure the DynamicSupervisor itself is truly cleaned up from the Supervisor's perspective,
+    # so that it will restart reliably
+    :ok = Supervisor.terminate_child(module_supervisor, @dynamic_supervisor_id)
 
-      # Restart the dynamic supervisor
-      if Keyword.get(options, :restart_supervisor, true) do
-        {:ok, _pid} = Supervisor.restart_child(module_supervisor, :worker_dynamic_supervisor)
-      end
-    end)
+    # Restart the dynamic supervisor
+    if Keyword.get(options, :restart_supervisor, true) do
+      {:ok, _pid} = Supervisor.restart_child(module_supervisor, @dynamic_supervisor_id)
+    end
 
     %{}
   end
@@ -179,8 +173,9 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
       )
     end
 
-    supervisor = {:via, ElsaRegistry, {registry(state.connection), :worker_dynamic_supervisor}}
-    {:ok, worker_pid} = DynamicSupervisor.start_child(supervisor, {Worker, init_args})
+    dynamic_supervisor = get_dynamic_supervisor(get_worker_supervisor(state.connection))
+
+    {:ok, worker_pid} = DynamicSupervisor.start_child(dynamic_supervisor, {Worker, init_args})
     ref = Process.monitor(worker_pid)
 
     new_worker = %WorkerState{
@@ -201,5 +196,16 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
     workers
     |> Map.values()
     |> Enum.find(fn worker -> worker.ref == ref end)
+  end
+
+  defp get_worker_supervisor(connection) do
+    Util.with_registry(connection, fn registry ->
+      ElsaRegistry.whereis_name({registry, __MODULE__})
+    end)
+  end
+
+  defp get_dynamic_supervisor(worker_supervisor_pid) do
+    [{@dynamic_supervisor_id, dynamic_worker_supervisor, _, _}] = Supervisor.which_children(worker_supervisor_pid)
+    dynamic_worker_supervisor
   end
 end

--- a/lib/elsa/group/manager/worker_supervisor.ex
+++ b/lib/elsa/group/manager/worker_supervisor.ex
@@ -45,12 +45,13 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
     connection = Keyword.fetch!(opts, :connection)
 
     children = [
-      {DynamicSupervisor,
-       [
-         id: :worker_dynamic_supervisor,
-         name: {:via, ElsaRegistry, {registry(connection), :worker_dynamic_supervisor}},
-         restart: :transient
-       ]}
+      %{
+        id: :worker_dynamic_supervisor,
+        start:
+          {DynamicSupervisor, :start_link,
+           [[name: {:via, ElsaRegistry, {registry(connection), :worker_dynamic_supervisor}}]]},
+        restart: :transient
+      }
     ]
 
     Supervisor.init(children,

--- a/lib/elsa/group/manager/worker_supervisor.ex
+++ b/lib/elsa/group/manager/worker_supervisor.ex
@@ -3,7 +3,7 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
   Provides functions to encapsulate the management of worker
   processes by the consumer group manager.
   """
-  use Supervisor, restart: :transient
+  use Supervisor
 
   import Record, only: [defrecord: 2, extract: 2]
   import Elsa.ElsaSupervisor, only: [registry: 1]
@@ -46,7 +46,11 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
 
     children = [
       {DynamicSupervisor,
-       [id: :worker_dynamic_supervisor, name: {:via, ElsaRegistry, {registry(connection), :worker_dynamic_supervisor}}]}
+       [
+         id: :worker_dynamic_supervisor,
+         name: {:via, ElsaRegistry, {registry(connection), :worker_dynamic_supervisor}},
+         restart: :transient
+       ]}
     ]
 
     Supervisor.init(children,
@@ -81,7 +85,7 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
     workers
     |> Map.values()
     |> Enum.each(fn worker ->
-      Logger.info("Gracefully stopping group worker #{inspect(worker)}")
+      Logger.info("#{__MODULE__}: Gracefully stopping group worker #{inspect(worker)}")
       Process.demonitor(worker.ref)
     end)
 
@@ -92,12 +96,18 @@ defmodule Elsa.Group.Manager.WorkerSupervisor do
       # This is the DynamicSupervisor created in init
       dynamic_worker_supervisor = ElsaRegistry.whereis_name({registry, :worker_dynamic_supervisor})
 
-      # Synchronously stops the DynamicSupervisor and its children
-      DynamicSupervisor.stop(dynamic_worker_supervisor)
+      if dynamic_worker_supervisor != :undefined do
+        # Synchronously stops the DynamicSupervisor and its children
+        DynamicSupervisor.stop(dynamic_worker_supervisor)
 
-      # Make sure the DynamicSupervisor itself is truly cleaned up from the Supervisor's perspective,
-      # so that it will restart reliably
-      _ = Supervisor.terminate_child(module_supervisor, :worker_dynamic_supervisor)
+        # Make sure the DynamicSupervisor itself is truly cleaned up from the Supervisor's perspective,
+        # so that it will restart reliably
+        _ = Supervisor.terminate_child(module_supervisor, :worker_dynamic_supervisor)
+      else
+        Logger.warn(
+          "#{__MODULE__}: Attempted to stop :worker_dynamic_supervisor, but it does not exist under #{inspect(connection)}"
+        )
+      end
 
       # Restart the dynamic supervisor
       if Keyword.get(options, :restart_supervisor, true) do

--- a/test/unit/elsa/group/lifecycle_hooks_test.exs
+++ b/test/unit/elsa/group/lifecycle_hooks_test.exs
@@ -32,13 +32,17 @@ defmodule Elsa.Group.LifecycleHooksTest do
         send(test_pid, :assignments_revoked)
         :ok
       end,
+      assignments_complete_handler: fn group, generation_id, result ->
+        send(test_pid, {:assignments_complete, group, generation_id, result})
+        :ok
+      end,
       generation_id: :generation_id
     }
 
     [state: state]
   end
 
-  test "assignments_recieved calls lifecycle hook", %{state: state} do
+  test "assignment_recieved/assignments_complete calls lifecycle hook", %{state: state} do
     with_mocks([
       {Elsa.ElsaRegistry, [], [whereis_name: fn _ -> :ack_pid end]},
       {Acknowledger, [], [update_generation_id: fn _, _ -> :ok end]}
@@ -53,6 +57,7 @@ defmodule Elsa.Group.LifecycleHooksTest do
 
       assert_received {:assignment_received, "group1", "topic1", 0, :generation_id}
       assert_received {:assignment_received, "group1", "topic1", 1, :generation_id}
+      assert_received {:assignments_complete, "group1", :generation_id, :ok}
     end
   end
 

--- a/test/unit/elsa/group/lifecycle_hooks_test.exs
+++ b/test/unit/elsa/group/lifecycle_hooks_test.exs
@@ -42,7 +42,7 @@ defmodule Elsa.Group.LifecycleHooksTest do
     [state: state]
   end
 
-  test "assignment_recieved/assignments_complete calls lifecycle hook", %{state: state} do
+  test "assignment_received/assignments_complete calls lifecycle hook", %{state: state} do
     with_mocks([
       {Elsa.ElsaRegistry, [], [whereis_name: fn _ -> :ack_pid end]},
       {Acknowledger, [], [update_generation_id: fn _, _ -> :ok end]}


### PR DESCRIPTION
This should now completely fix the following issue: 

https://github.com/simplifi/elsa_fi/issues/15
(Internal issue tracking): https://simplifi.atlassian.net/browse/INT-11499
https://simplifi.atlassian.net/browse/INT-11494

Two changes in this one:

First, added a callback that you can get when a batch of assignments is complete.  This should make it easier to write stable integration tests, i.e. you can subscribe to a topic using `latest` for the offset, wait for assignments complete, and _then_ publish.

Second, reworked WorkerSupervisor's supervision tree:
* Fixed where we set `restart: :transient` -- it was simply in the wrong place before, the intent all along was to have the underlying DynamicSupervisor to be transient, not the module-based Supervisor.
* Fixed a race condition by no longer putting the underlying DynamicSupervisor in ElsaRegistry.  The problem was that ElsaRegistry does not _synchronously_ remove the keys of dead processes, so we were intermittently getting an `{:error, :already_started}` from Supervisor.restart_child.  This could have also been fixed with an explicit call to `ElsaRegistry.unregister_name/2`, but there's no benefit to having this transient particular process in the registry anyway.  It just muddies up the picture really.