### PR TITLE
Better name for ready?

### DIFF
--- a/lib/elsa/dynamic_process_manager.ex
+++ b/lib/elsa/dynamic_process_manager.ex
@@ -23,7 +23,7 @@ defmodule Elsa.DynamicProcessManager do
     }
   end
 
-  def wait_ready!(server, timeout \\ 10_000) do
+  def wait_ready(server, timeout \\ 10_000) do
     GenServer.call(server, :ready?, timeout)
   end
 

--- a/lib/elsa/dynamic_process_manager.ex
+++ b/lib/elsa/dynamic_process_manager.ex
@@ -23,7 +23,7 @@ defmodule Elsa.DynamicProcessManager do
     }
   end
 
-  def ready?(server, timeout \\ 10_000) do
+  def wait_ready!(server, timeout \\ 10_000) do
     GenServer.call(server, :ready?, timeout)
   end
 

--- a/lib/elsa/producer.ex
+++ b/lib/elsa/producer.ex
@@ -65,22 +65,22 @@ defmodule Elsa.Producer do
   end
 
   @doc "Waits until the Producer's underlying GenServer has completed its initialization and is responding to messages."
-  def wait_ready!(connection, timeout \\ 10_000) do
+  def wait_ready(connection, timeout \\ 10_000) do
     registry = ElsaSupervisor.registry(connection)
     via = ElsaSupervisor.via_name(registry, :producer_process_manager)
-    Elsa.DynamicProcessManager.wait_ready!(via, timeout)
+    Elsa.DynamicProcessManager.wait_ready(via, timeout)
   end
 
-  @doc "deprecated"
+  @doc "Deprecated.  Please use wait_ready instead."
   def ready?(connection) do
-    wait_ready!(connection)
+    wait_ready(connection)
     true
   end
 
   defp ad_hoc_produce(endpoints, connection, topic, messages, opts) do
     with {:ok, pid} <-
            ElsaSupervisor.start_link(endpoints: endpoints, connection: connection, producer: [topic: topic]) do
-      wait_ready!(connection)
+      wait_ready(connection)
       _ = produce(connection, topic, messages, opts)
       Process.unlink(pid)
       Supervisor.stop(pid)

--- a/lib/elsa/producer.ex
+++ b/lib/elsa/producer.ex
@@ -64,16 +64,23 @@ defmodule Elsa.Producer do
     do_produce_sync(connection, topic, [transform_message(message)], opts)
   end
 
-  def ready?(connection) do
+  @doc "Waits until the Producer's underlying GenServer has completed its initialization and is responding to messages."
+  def wait_ready!(connection, timeout \\ 10_000) do
     registry = ElsaSupervisor.registry(connection)
     via = ElsaSupervisor.via_name(registry, :producer_process_manager)
-    Elsa.DynamicProcessManager.ready?(via)
+    Elsa.DynamicProcessManager.wait_ready!(via, timeout)
+  end
+
+  @doc "deprecated"
+  def ready?(connection) do
+    wait_ready!(connection)
+    true
   end
 
   defp ad_hoc_produce(endpoints, connection, topic, messages, opts) do
     with {:ok, pid} <-
            ElsaSupervisor.start_link(endpoints: endpoints, connection: connection, producer: [topic: topic]) do
-      ready?(connection)
+      wait_ready!(connection)
       _ = produce(connection, topic, messages, opts)
       Process.unlink(pid)
       Supervisor.stop(pid)

--- a/test/integration/elsa/consumer/worker_test.exs
+++ b/test/integration/elsa/consumer/worker_test.exs
@@ -107,7 +107,7 @@ defmodule Elsa.Consumer.WorkerTest do
         ]
       )
 
-    Patiently.wait_for(fn -> Elsa.Producer.wait_ready!(connection) end)
+    Patiently.wait_for(fn -> Elsa.Producer.wait_ready(connection) end)
     Elsa.produce(@endpoints, topic, {"2", "homerun"}, partition: 0)
 
     assert_receive [%Elsa.Message{value: "homerun"}], 5_000

--- a/test/integration/elsa/consumer/worker_test.exs
+++ b/test/integration/elsa/consumer/worker_test.exs
@@ -107,7 +107,7 @@ defmodule Elsa.Consumer.WorkerTest do
         ]
       )
 
-    Patiently.wait_for(fn -> Elsa.Producer.ready?(connection) end)
+    Patiently.wait_for(fn -> Elsa.Producer.wait_ready!(connection) end)
     Elsa.produce(@endpoints, topic, {"2", "homerun"}, partition: 0)
 
     assert_receive [%Elsa.Message{value: "homerun"}], 5_000

--- a/test/integration/elsa/producer_test.exs
+++ b/test/integration/elsa/producer_test.exs
@@ -34,7 +34,7 @@ defmodule Elsa.ProducerTest do
         assert_down(supervisor)
       end)
 
-      Producer.ready?(connection)
+      Producer.wait_ready!(connection)
 
       [connection: connection, topics: [topic, topic2], registry: ElsaSupervisor.registry(connection)]
     end
@@ -57,7 +57,7 @@ defmodule Elsa.ProducerTest do
         max_tries: 30
       )
 
-      Producer.ready?(connection)
+      Producer.wait_ready!(connection)
 
       Producer.produce(connection, topic, message)
       Producer.produce(connection, topic2, message2)
@@ -90,7 +90,7 @@ defmodule Elsa.ProducerTest do
 
       on_exit(fn -> assert_down(supervisor) end)
 
-      Producer.ready?(connection)
+      Producer.wait_ready!(connection)
 
       patient_produce(connection, topic, messages, produce_opts)
 
@@ -138,7 +138,7 @@ defmodule Elsa.ProducerTest do
 
       on_exit(fn -> assert_down(supervisor) end)
 
-      Producer.ready?(connection)
+      Producer.wait_ready!(connection)
 
       messages = [
         %{key: "key1", value: "value1", headers: [{"header1", "one"}, {"header2", "two"}]},
@@ -176,7 +176,7 @@ defmodule Elsa.ProducerTest do
 
       on_exit(fn -> assert_down(supervisor) end)
 
-      Producer.ready?(connection)
+      Producer.wait_ready!(connection)
 
       patient_produce(connection, "random-topic", [{"key1", "value1"}, {"key2", "value2"}],
         partitioner: Elsa.Partitioner.Random
@@ -196,7 +196,7 @@ defmodule Elsa.ProducerTest do
 
       on_exit(fn -> assert_down(supervisor) end)
 
-      Producer.ready?(connection)
+      Producer.wait_ready!(connection)
 
       patient_produce(connection, "hashed-topic", {"key", "value"}, partitioner: Elsa.Partitioner.Md5)
 
@@ -216,7 +216,7 @@ defmodule Elsa.ProducerTest do
 
       on_exit(fn -> assert_down(supervisor) end)
 
-      Producer.ready?(connection)
+      Producer.wait_ready!(connection)
 
       patient_produce(connection, topic, {"key", "value"}, partitioner: :default)
 
@@ -250,7 +250,7 @@ defmodule Elsa.ProducerTest do
 
       ElsaSupervisor.start_producer(connection, topic: topic1)
 
-      Producer.ready?(connection)
+      Producer.wait_ready!(connection)
 
       patient_produce(connection, topic1, {"key1", "value1"}, [])
 

--- a/test/integration/elsa/producer_test.exs
+++ b/test/integration/elsa/producer_test.exs
@@ -34,7 +34,7 @@ defmodule Elsa.ProducerTest do
         assert_down(supervisor)
       end)
 
-      Producer.wait_ready!(connection)
+      Producer.wait_ready(connection)
 
       [connection: connection, topics: [topic, topic2], registry: ElsaSupervisor.registry(connection)]
     end
@@ -57,7 +57,7 @@ defmodule Elsa.ProducerTest do
         max_tries: 30
       )
 
-      Producer.wait_ready!(connection)
+      Producer.wait_ready(connection)
 
       Producer.produce(connection, topic, message)
       Producer.produce(connection, topic2, message2)
@@ -90,7 +90,7 @@ defmodule Elsa.ProducerTest do
 
       on_exit(fn -> assert_down(supervisor) end)
 
-      Producer.wait_ready!(connection)
+      Producer.wait_ready(connection)
 
       patient_produce(connection, topic, messages, produce_opts)
 
@@ -138,7 +138,7 @@ defmodule Elsa.ProducerTest do
 
       on_exit(fn -> assert_down(supervisor) end)
 
-      Producer.wait_ready!(connection)
+      Producer.wait_ready(connection)
 
       messages = [
         %{key: "key1", value: "value1", headers: [{"header1", "one"}, {"header2", "two"}]},
@@ -176,7 +176,7 @@ defmodule Elsa.ProducerTest do
 
       on_exit(fn -> assert_down(supervisor) end)
 
-      Producer.wait_ready!(connection)
+      Producer.wait_ready(connection)
 
       patient_produce(connection, "random-topic", [{"key1", "value1"}, {"key2", "value2"}],
         partitioner: Elsa.Partitioner.Random
@@ -196,7 +196,7 @@ defmodule Elsa.ProducerTest do
 
       on_exit(fn -> assert_down(supervisor) end)
 
-      Producer.wait_ready!(connection)
+      Producer.wait_ready(connection)
 
       patient_produce(connection, "hashed-topic", {"key", "value"}, partitioner: Elsa.Partitioner.Md5)
 
@@ -216,7 +216,7 @@ defmodule Elsa.ProducerTest do
 
       on_exit(fn -> assert_down(supervisor) end)
 
-      Producer.wait_ready!(connection)
+      Producer.wait_ready(connection)
 
       patient_produce(connection, topic, {"key", "value"}, partitioner: :default)
 
@@ -250,7 +250,7 @@ defmodule Elsa.ProducerTest do
 
       ElsaSupervisor.start_producer(connection, topic: topic1)
 
-      Producer.wait_ready!(connection)
+      Producer.wait_ready(connection)
 
       patient_produce(connection, topic1, {"key1", "value1"}, [])
 

--- a/test/unit/elsa/dynamic_process_manager_test.exs
+++ b/test/unit/elsa/dynamic_process_manager_test.exs
@@ -85,7 +85,7 @@ defmodule DynamicProcessManagerTest do
         poll: 1_000
       })
 
-    DynamicProcessManager.wait_ready!(pm)
+    DynamicProcessManager.wait_ready(pm)
 
     assert true == alive?(:agent1)
     assert 1 == Agent.get(:agent1, fn s -> s end)

--- a/test/unit/elsa/dynamic_process_manager_test.exs
+++ b/test/unit/elsa/dynamic_process_manager_test.exs
@@ -85,7 +85,7 @@ defmodule DynamicProcessManagerTest do
         poll: 1_000
       })
 
-    DynamicProcessManager.ready?(pm)
+    DynamicProcessManager.wait_ready!(pm)
 
     assert true == alive?(:agent1)
     assert 1 == Agent.get(:agent1, fn s -> s end)


### PR DESCRIPTION
Producer.ready? does not really behave like a predicate.  Rather it blocks then returns true on success, or raises an exception on timeout.  I think `wait_ready!` is therefore a better name.

https://simplifi.atlassian.net/browse/INT-11818