### PR TITLE
enable self healing after offset out of range kafka error

### DIFF
--- a/lib/elsa/consumer/worker.ex
+++ b/lib/elsa/consumer/worker.ex
@@ -5,6 +5,36 @@ defmodule Elsa.Consumer.Worker do
   and process messages according to the specified message handler module
   passed in from the manager before calling the ack function to
   notify the cluster the messages have been successfully processed.
+
+  ## Self-healing on `offset_out_of_range`
+
+  Under brod's default `offset_reset_policy: reset_by_subscriber`, when a
+  committed offset falls outside the available log (topic recreated, retention
+  truncation, cluster cutover), brod casts a `kafka_fetch_error` with
+  `error_code: :offset_out_of_range` and suspends fetching. The worker handles
+  this by **re-subscribing in place** at `config[:begin_offset]` (default
+  `:latest`), which un-suspends brod and resumes consumption without a process
+  restart.
+
+  Because the reset jumps to the policy target, **messages between the stale
+  committed offset and the reset target may be skipped**. Callers running
+  non-idempotent handlers should be aware that a reset can cause records to be
+  dropped (with `:latest`) — and conversely, replay/double-processing is
+  possible if you choose `:earliest`. Callers needing replay should set
+  `begin_offset: :earliest` and design their handlers to tolerate reprocessing.
+
+  This self-heal only applies under `reset_by_subscriber`. With the `:reset_to_latest`
+  / `:reset_to_earliest` policies brod resets internally and never casts the error,
+  so the worker's `offset_out_of_range` clause never fires.
+
+  If re-subscribe fails after exhausting retries, the worker stops with
+  `{:resubscribe_failed, reason}` (fail loud — never silently stall). Group
+  consumers recover via `Elsa.Group.Manager`'s monitor, which restarts the
+  worker. **Simple consumers (`Elsa.Consumer.Worker.Initializer`) are
+  `restart: :temporary` with no monitor, so a stopped worker is not restarted
+  automatically — they require external supervision.** This is an accepted,
+  documented limitation: the in-place re-subscribe happy path is what protects
+  simple consumers; the `:stop` is only the failure path.
   """
   use GenServer, restart: :temporary, shutdown: 10_000
 
@@ -17,6 +47,7 @@ defmodule Elsa.Consumer.Worker do
   require Logger
 
   defrecord :kafka_message_set, extract(:kafka_message_set, from_lib: "brod/include/brod.hrl")
+  defrecord :kafka_fetch_error, extract(:kafka_fetch_error, from_lib: "brod/include/brod.hrl")
 
   @subscribe_delay 200
   @subscribe_retries 20
@@ -126,6 +157,38 @@ defmodule Elsa.Consumer.Worker do
     end
   end
 
+  def handle_info({consumer_pid, kafka_fetch_error(error_code: :offset_out_of_range)}, state)
+      when consumer_pid == state.consumer_pid do
+    Logger.warning(
+      "Offset out of range for #{state.topic}/#{state.partition} " <>
+        "(was #{inspect(state.offset)}); resetting to " <>
+        "#{inspect(Keyword.get(state.config, :begin_offset, :latest))} per policy and re-subscribing"
+    )
+
+    # :undefined makes determine_subscriber_opts/1 fall back to config begin_offset.
+    new_state = %{state | offset: :undefined}
+
+    case subscribe(consumer_pid, new_state) do
+      :ok ->
+        {:noreply, new_state}
+
+      {:error, reason} ->
+        {:stop, {:resubscribe_failed, reason}, state}
+    end
+  end
+
+  def handle_info(
+        {consumer_pid, kafka_fetch_error(error_code: code, error_desc: desc)},
+        state
+      )
+      when consumer_pid == state.consumer_pid do
+    Logger.error("Unhandled kafka_fetch_error #{inspect(code)} for #{state.topic}/#{state.partition}: #{inspect(desc)}")
+
+    # For these codes brod stops the (linked) consumer, so the worker then stops
+    # via the {:EXIT, ...} clause below; this {:noreply, state} just logs first.
+    {:noreply, state}
+  end
+
   def handle_info({:EXIT, _pid, reason}, state) do
     {:stop, reason, state}
   end
@@ -162,13 +225,16 @@ defmodule Elsa.Consumer.Worker do
     :brod_consumer.start_link(brod_client, topic, partition, config)
   end
 
-  defp subscribe(consumer_pid, state, retries \\ @subscribe_retries)
+  defp subscribe(consumer_pid, state) do
+    retries = Keyword.get(state.config, :subscribe_retries, @subscribe_retries)
+    do_subscribe(consumer_pid, state, retries)
+  end
 
-  defp subscribe(_consumer_pid, _state, 0) do
+  defp do_subscribe(_consumer_pid, _state, 0) do
     {:error, :failed_subscription}
   end
 
-  defp subscribe(consumer_pid, state, retries) do
+  defp do_subscribe(consumer_pid, state, retries) do
     opts = determine_subscriber_opts(state)
 
     case :brod_consumer.subscribe(consumer_pid, self(), opts) do
@@ -177,8 +243,8 @@ defmodule Elsa.Consumer.Worker do
           "Retrying to subscribe to topic #{state.topic} parition #{state.partition} offset #{state.offset} reason #{inspect(reason)}"
         )
 
-        Process.sleep(@subscribe_delay)
-        subscribe(consumer_pid, state, retries - 1)
+        Process.sleep(Keyword.get(state.config, :subscribe_delay, @subscribe_delay))
+        do_subscribe(consumer_pid, state, retries - 1)
 
       :ok ->
         Logger.info("Subscribing to topic #{state.topic} partition #{state.partition} offset #{state.offset}")

--- a/test/integration/elsa/consumer/offset_out_of_range_test.exs
+++ b/test/integration/elsa/consumer/offset_out_of_range_test.exs
@@ -1,0 +1,73 @@
+defmodule Elsa.Consumer.OffsetOutOfRangeTest do
+  @moduledoc """
+  Forces `offset_out_of_range` for a simple consumer by subscribing at a
+  `begin_offset` past the high-water mark of a fresh topic; brod's first fetch
+  returns the error, which the worker heals by re-subscribing.
+  """
+  use ExUnit.Case
+  use Divo
+
+  @endpoints Application.compile_env(:elsa_fi, :brokers)
+
+  defmodule ForwardingHandler do
+    use Elsa.Consumer.MessageHandler
+
+    def handle_messages(messages, %{pid: pid} = state) do
+      Enum.each(messages, &send(pid, {:message, &1}))
+      {:ack, state}
+    end
+  end
+
+  @tag :offset_out_of_range
+  test "self-heals an out-of-range begin offset and resumes consuming at :latest" do
+    topic = "oor-selfheal-topic"
+
+    Patiently.wait_for!(
+      fn -> :ok == Elsa.create_topic(@endpoints, topic, partitions: 1) end,
+      dwell: 1_000,
+      max_tries: 30
+    )
+
+    {:ok, sup} =
+      Elsa.ElsaSupervisor.start_link(
+        connection: :oor_selfheal,
+        endpoints: @endpoints,
+        consumer: [
+          topic: topic,
+          partition: 0,
+          # Past the high-water mark -> offset_out_of_range on the first fetch.
+          begin_offset: 1_000_000,
+          # Reset target after OOR.
+          config: [begin_offset: :latest],
+          handler: ForwardingHandler,
+          handler_init_args: %{pid: self()}
+        ]
+      )
+
+    # A :latest reset only delivers messages produced after re-subscribe, so re-produce
+    # until one lands (polls for the reset, no sleep).
+    assert_eventually_consumes(
+      fn -> Elsa.produce(@endpoints, topic, {"k", "after-reset"}, partition: 0) end,
+      "after-reset"
+    )
+
+    Supervisor.stop(sup)
+  end
+
+  # Produce repeatedly until a message with `value` is delivered, or fail.
+  defp assert_eventually_consumes(produce_fun, value, attempts \\ 30, delay \\ 500)
+
+  defp assert_eventually_consumes(_produce_fun, value, 0, _delay) do
+    flunk("never consumed #{inspect(value)} after re-subscribe")
+  end
+
+  defp assert_eventually_consumes(produce_fun, value, attempts, delay) do
+    :ok = produce_fun.()
+
+    receive do
+      {:message, %Elsa.Message{value: ^value}} -> :ok
+    after
+      delay -> assert_eventually_consumes(produce_fun, value, attempts - 1, delay)
+    end
+  end
+end

--- a/test/integration/elsa/group/offset_out_of_range_test.exs
+++ b/test/integration/elsa/group/offset_out_of_range_test.exs
@@ -1,0 +1,172 @@
+defmodule Elsa.Group.OffsetOutOfRangeTest do
+  @moduledoc """
+  Group-consumer counterpart to `Elsa.Consumer.OffsetOutOfRangeTest`.
+
+  A group consumer takes its start offset from the committed group offset, not config
+  (see `brod_group_coordinator:resolve_begin_offsets/3`), so to trigger
+  offset_out_of_range we make the *committed* offset invalid: commit a valid offset,
+  grow the log, then advance the partition's log-start past it with `delete_records`
+  (retention truncation). The topic is never deleted — that would drop the committed
+  offset and the rejoin would start clean, never hitting OOR.
+  """
+  use ExUnit.Case
+  use Divo
+
+  import Record, only: [defrecord: 2, extract: 2]
+
+  alias Elsa.Util, as: ElsaUtil
+
+  @endpoints Application.compile_env(:elsa_fi, :brokers)
+  @partition 0
+  # Truncate the log front to this offset. Must sit above the committed offset (<= 3)
+  # and below the high-water mark (13) so the committed offset becomes out of range.
+  @truncate_before 8
+
+  defrecord :kpro_rsp, extract(:kpro_rsp, from_lib: "kafka_protocol/include/kpro.hrl")
+
+  defmodule ForwardingHandler do
+    use Elsa.Consumer.MessageHandler
+
+    def handle_messages(messages, %{pid: pid} = state) do
+      Enum.each(messages, &send(pid, {:message, &1}))
+      {:ack, state}
+    end
+  end
+
+  @tag :offset_out_of_range
+  test "group consumer self-heals when retention truncates past the committed offset" do
+    topic = "oor-group-topic"
+    group = "oor-group-#{:erlang.unique_integer([:positive])}"
+
+    create_topic!(topic)
+
+    # Consume, then wait until the group commits. Polling the real offset (not sleeping)
+    # also guards a false pass: no commit -> no OOR on rejoin.
+    {:ok, sup1} = start_group(:oor_group_first, topic, group, :earliest)
+
+    Enum.each(1..3, fn n -> :ok = Elsa.produce(@endpoints, topic, {"k", "msg#{n}"}, partition: @partition) end)
+    assert_receive {:message, %Elsa.Message{value: "msg1"}}, 5_000
+    assert_receive {:message, %Elsa.Message{value: "msg2"}}, 5_000
+    assert_receive {:message, %Elsa.Message{value: "msg3"}}, 5_000
+
+    committed = await_committed_offset(group, topic, @partition)
+
+    assert committed < @truncate_before,
+           "committed offset #{committed} must be below the truncation point #{@truncate_before} " <>
+             "for it to become out of range"
+
+    Supervisor.stop(sup1)
+
+    # Grow the log, then truncate its front past the committed offset -> the committed
+    # offset is now out of range.
+    Enum.each(4..13, fn n -> :ok = Elsa.produce(@endpoints, topic, {"k", "fill#{n}"}, partition: @partition) end)
+    :ok = truncate_log_before(topic, @partition, @truncate_before)
+
+    # Rejoin the same group. brod fetches the committed offset (below log-start) ->
+    # offset_out_of_range. A :latest reset only delivers post-reset messages, so
+    # re-produce until one lands.
+    {:ok, sup2} = start_group(:oor_group_rejoin, topic, group, :latest)
+
+    assert_eventually_consumes(
+      fn -> Elsa.produce(@endpoints, topic, {"k", "after-reset"}, partition: @partition) end,
+      "after-reset"
+    )
+
+    Supervisor.stop(sup2)
+  end
+
+  defp start_group(connection, topic, group, reset_to) do
+    Elsa.ElsaSupervisor.start_link(
+      connection: connection,
+      endpoints: @endpoints,
+      group_consumer: [
+        group: group,
+        topics: [topic],
+        handler: ForwardingHandler,
+        handler_init_args: %{pid: self()},
+        config: [begin_offset: reset_to, offset_commit_interval_seconds: 1]
+      ]
+    )
+  end
+
+  defp create_topic!(topic) do
+    Patiently.wait_for!(
+      fn -> :ok == Elsa.create_topic(@endpoints, topic, partitions: 1) end,
+      dwell: 1_000,
+      max_tries: 30
+    )
+  end
+
+  # Poll until Kafka reports a committed offset for the partition, then return it.
+  defp await_committed_offset(group, topic, partition) do
+    Patiently.wait_for!(
+      fn -> committed_offset(group, topic, partition) >= 0 end,
+      dwell: 200,
+      max_tries: 50
+    )
+
+    committed_offset(group, topic, partition)
+  end
+
+  defp committed_offset(group, topic, partition) do
+    case :brod.fetch_committed_offsets(@endpoints, [], group) do
+      {:ok, topics} ->
+        topics
+        |> Enum.find(%{}, &(&1.name == topic))
+        |> Map.get(:partitions, [])
+        |> Enum.find(%{}, &(&1.partition_index == partition))
+        |> Map.get(:committed_offset, -1)
+
+      _ ->
+        -1
+    end
+  end
+
+  # Advance the partition's log-start to `before_offset` (retention truncation).
+  # delete_records is a partition-leader request; the single-broker cluster makes
+  # `:any` the leader. Asserts it took effect.
+  defp truncate_log_before(topic, partition, before_offset) do
+    ElsaUtil.with_connection(@endpoints, :any, fn connection ->
+      vsn = ElsaUtil.get_api_version(connection, :delete_records)
+
+      request =
+        :kpro.make_request(:delete_records, vsn, %{
+          topics: [%{topic: topic, partitions: [%{partition: partition, offset: before_offset}]}],
+          timeout: 5_000
+        })
+
+      {:ok, response} = :kpro.request_sync(connection, request, 10_000)
+
+      partition_result =
+        kpro_rsp(response, :msg).topics
+        |> Enum.find(&(&1.topic == topic))
+        |> Map.fetch!(:partitions)
+        |> Enum.find(&(&1.partition == partition))
+
+      assert partition_result.error_code == :no_error,
+             "delete_records failed: #{inspect(partition_result)}"
+
+      assert partition_result.low_watermark == before_offset,
+             "expected log-start #{before_offset}, got #{partition_result.low_watermark}"
+
+      :ok
+    end)
+  end
+
+  # Produce repeatedly until a message with `value` is delivered, or fail.
+  defp assert_eventually_consumes(produce_fun, value, attempts \\ 30, delay \\ 500)
+
+  defp assert_eventually_consumes(_produce_fun, value, 0, _delay) do
+    flunk("never consumed #{inspect(value)} after re-subscribe")
+  end
+
+  defp assert_eventually_consumes(produce_fun, value, attempts, delay) do
+    :ok = produce_fun.()
+
+    receive do
+      {:message, %Elsa.Message{value: ^value}} -> :ok
+    after
+      delay -> assert_eventually_consumes(produce_fun, value, attempts - 1, delay)
+    end
+  end
+end

--- a/test/unit/elsa/consumer/worker_test.exs
+++ b/test/unit/elsa/consumer/worker_test.exs
@@ -3,7 +3,8 @@ defmodule Elsa.Consumer.WorkerTest do
 
   import Checkov
   import Mock
-  import Elsa.Consumer.Worker, only: [kafka_message_set: 1]
+  import ExUnit.CaptureLog
+  import Elsa.Consumer.Worker, only: [kafka_message_set: 1, kafka_fetch_error: 1]
   import Elsa.Message, only: [kafka_message: 1]
 
   alias Elsa.Consumer.Worker
@@ -87,6 +88,111 @@ defmodule Elsa.Consumer.WorkerTest do
 
       where ack: [:ack, :acknowledge]
     end
+  end
+
+  describe "handle_info/2 offset_out_of_range" do
+    setup_with_mocks([
+      {:brod_consumer, [], [subscribe: fn _, _, _ -> :ok end, ack: fn _, _ -> :ok end]}
+    ]) do
+      # consumer_pid is a distinct process from the test process so that
+      # assertions on subscribe/3's first arg meaningfully pin it (a pid-swap
+      # regression in the worker would then be caught).
+      consumer_pid = spawn(fn -> :ok end)
+      state = build_worker_state(consumer_pid: consumer_pid)
+
+      {:ok, state: state, consumer_pid: consumer_pid}
+    end
+
+    test "re-subscribes in place and stays alive, resetting offset to :undefined", %{
+      state: state,
+      consumer_pid: consumer_pid
+    } do
+      res = Worker.handle_info({consumer_pid, kafka_fetch_error(error_code: :offset_out_of_range)}, state)
+      assert {:noreply, new_state} = res
+
+      assert new_state.offset == :undefined
+      # Exactly once — a retry-loop regression (re-subscribing repeatedly) would fail this.
+      assert_called_exactly(:brod_consumer.subscribe(consumer_pid, :_, begin_offset: :latest), 1)
+    end
+
+    test "re-subscribes using config begin_offset when set", %{
+      state: state,
+      consumer_pid: consumer_pid
+    } do
+      state = %{state | config: [begin_offset: :earliest]}
+
+      assert {:noreply, _new_state} =
+               Worker.handle_info({consumer_pid, kafka_fetch_error(error_code: :offset_out_of_range)}, state)
+
+      assert_called_exactly(:brod_consumer.subscribe(consumer_pid, :_, begin_offset: :earliest), 1)
+    end
+
+    test "other fetch-error codes are logged and the worker stays alive without re-subscribing", %{
+      state: state,
+      consumer_pid: consumer_pid
+    } do
+      error = kafka_fetch_error(error_code: :unknown_topic_or_partition, error_desc: "nope")
+
+      log =
+        capture_log(fn ->
+          assert {:noreply, ^state} = Worker.handle_info({consumer_pid, error}, state)
+        end)
+
+      assert log =~ "unknown_topic_or_partition"
+      assert_not_called(:brod_consumer.subscribe(:_, :_, :_))
+    end
+
+    test "ignores fetch_error casts from a non-matching consumer_pid (guard)", %{state: state} do
+      other_pid = spawn(fn -> :ok end)
+
+      # A stale/previous consumer pid must not trigger a re-subscribe of the current
+      # consumer. With no matching clause the message is not acted on (it does not
+      # call subscribe); the worker raises rather than silently re-subscribing.
+      assert_raise FunctionClauseError, fn ->
+        Worker.handle_info({other_pid, kafka_fetch_error(error_code: :offset_out_of_range)}, state)
+      end
+
+      assert_not_called(:brod_consumer.subscribe(:_, :_, :_))
+    end
+  end
+
+  describe "handle_info/2 offset_out_of_range fail-loud" do
+    setup_with_mocks([
+      {:brod_consumer, [], [subscribe: fn _, _, _ -> {:error, :no_leader} end, ack: fn _, _ -> :ok end]}
+    ]) do
+      consumer_pid = spawn(fn -> :ok end)
+      # subscribe_delay: 0 keeps the retry backoff instant instead of mocking
+      # Process.sleep/1, so the fail-loud path resolves without the ~4s wait.
+      state = build_worker_state(consumer_pid: consumer_pid, config: [subscribe_delay: 0])
+
+      {:ok, state: state, consumer_pid: consumer_pid}
+    end
+
+    test "stops with :resubscribe_failed and preserves original state", %{
+      state: state,
+      consumer_pid: consumer_pid
+    } do
+      # The stop returns the ORIGINAL state (not the offset: :undefined copy) so
+      # supervisors/manager see the offset that failed.
+      assert {:stop, {:resubscribe_failed, :failed_subscription}, ^state} =
+               Worker.handle_info({consumer_pid, kafka_fetch_error(error_code: :offset_out_of_range)}, state)
+    end
+  end
+
+  defp build_worker_state(overrides) do
+    base = %{
+      connection: :test_name,
+      topic: "test-topic",
+      partition: 0,
+      generation_id: 5,
+      offset: 13,
+      handler: Elsa.Consumer.WorkerTest.Handler,
+      handler_init_args: [],
+      config: [],
+      consumer_pid: nil
+    }
+
+    struct(Worker.State, Map.merge(base, Map.new(overrides)))
   end
 
   defp create_state(init_args) do


### PR DESCRIPTION
We noticed during the kafka upgrade a few weeks ago that some of our applications did not come back up cleanly and required a manual restart to start the consumers consuming again. I believe i've traced the issue back to a failure by elsa to handle an "offset out of range" error message that brod emits.  This PR just adds handling and a few test cases including some integration tests against an actual kafka using the divo lib. This change does entail the possibility for lost or replayed messages (depending on your config) - but with a no longer valid offset you're left with only 2 choices: Reset to earliest, or reset to latest. I tried to make that clear in the inline doc.

Closes https://simplifi.atlassian.net/browse/DSP1-498